### PR TITLE
Replacing the use of java.util.Random with java.security.SecureRandom

### DIFF
--- a/src/main/java/axiom/delauth/token/TokenGenerator.java
+++ b/src/main/java/axiom/delauth/token/TokenGenerator.java
@@ -2,7 +2,7 @@ package axiom.delauth.token;
 
 import org.apache.log4j.Logger;
 
-import java.util.Random;
+import java.security.SecureRandom;
 
 
 public class TokenGenerator {
@@ -13,7 +13,7 @@ public class TokenGenerator {
     private TokenStore tokenStore = new TokenStorePojo();
 
     public String generateToken(String username) {
-        String token = Integer.toHexString(new Random().nextInt(Integer.MAX_VALUE));
+        String token = Integer.toHexString(new SecureRandom().nextInt(Integer.MAX_VALUE));
 
         tokenStore.addToken(username, token);
 

--- a/src/main/java/axiom/saml/idp/IdGenerator.java
+++ b/src/main/java/axiom/saml/idp/IdGenerator.java
@@ -2,7 +2,7 @@ package axiom.saml.idp;
 
 import org.apache.log4j.Logger;
 
-import java.util.Random;
+import java.security.SecureRandom;
 
 
 /**
@@ -17,7 +17,7 @@ public class IdGenerator {
     } // should not be instantiated
 
     public static String generateId() {
-        String id = "_" + Integer.toHexString(new Random().nextInt(Integer.MAX_VALUE)) + "-" + Integer.toHexString(new Random().nextInt(Integer.MAX_VALUE));
+        String id = "_" + Integer.toHexString(new SecureRandom().nextInt(Integer.MAX_VALUE)) + "-" + Integer.toHexString(new SecureRandom().nextInt(Integer.MAX_VALUE));
         logger.debug("Generated Id: " + id);
         return id;
     }


### PR DESCRIPTION
java.security.SecureRandom offers a more-secure extension of java.util.Random which provides a cryptographically strong random number generator.

Why generate weak random numbers if you can generate secure random numbers instead?