### PR TITLE
Add support for Java 8

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,1 @@
-web: java $JAVA_OPTS -jar target/dependency/jetty-runner.jar --port $PORT target/*.war
+web: java $JAVA_OPTS -cp target/dependency/jetty-runner.jar org.mortbay.jetty.runner.Runner --port $PORT target/*.war

--- a/README.md
+++ b/README.md
@@ -23,6 +23,6 @@ To install and run Axiom locally with Jetty Runner:
     git clone git://github.com/ryanbrainard/axiom.git
     cd axiom
     mvn clean install
-    java $JAVA_OPTS -jar target/dependency/jetty-runner.jar target/*.war
+    java $JAVA_OPTS -cp target/dependency/jetty-runner.jar org.mortbay.jetty.runner.Runner target/*.war
 
 Then go to `http://localhost:8080` in your browser.

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
     <description>Axiom Single Sign-On Tools</description>
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <jetty-runner.version>7.4.5.v20110725</jetty-runner.version>
+        <jetty-runner.version>8.1.16.v20140903</jetty-runner.version>
         <newrelic.version>2.15.0</newrelic.version>
     </properties>
     <developers>


### PR DESCRIPTION
Update jetty-runner to support java 8.

When accessing the `http://localhost:8080` while running axiom using java 8, the following exception was being thrown.

```
ERROR: Compilation error
org.eclipse.jdt.internal.compiler.classfmt.ClassFormatException
	at org.eclipse.jdt.internal.compiler.classfmt.ClassFileReader.<init>(ClassFileReader.java:372)
	at org.apache.jasper.compiler.JDTJavaCompiler$1.findType(JDTJavaCompiler.java:367)
	at org.apache.jasper.compiler.JDTJavaCompiler$1.findType(JDTJavaCompiler.java:324)
	at org.eclipse.jdt.internal.compiler.lookup.LookupEnvironment.askForType(LookupEnvironment.java:102)
	at org.eclipse.jdt.internal.compiler.lookup.UnresolvedReferenceBinding.resolve(UnresolvedReferenceBinding.java:49)
	at org.eclipse.jdt.internal.compiler.lookup.BinaryTypeBinding.resolveType(BinaryTypeBinding.java:122)
	at org.eclipse.jdt.internal.compiler.lookup.PackageBinding.getTypeOrPackage(PackageBinding.java:168)

...
```